### PR TITLE
[squid:UselessImportCheck] Useless imports should be removed

### DIFF
--- a/app/src/main/java/me/daei/soundmeter/MyMediaRecorder.java
+++ b/app/src/main/java/me/daei/soundmeter/MyMediaRecorder.java
@@ -3,7 +3,6 @@ package me.daei.soundmeter;
 import java.io.File;
 import java.io.IOException;
 import android.media.MediaRecorder;
-import android.util.Log;
 
 public class MyMediaRecorder {
 	

--- a/app/src/main/java/me/daei/soundmeter/World.java
+++ b/app/src/main/java/me/daei/soundmeter/World.java
@@ -1,7 +1,5 @@
 package me.daei.soundmeter;
 
-import android.os.Environment;
-import android.widget.TextView;
 
 
 public class World {

--- a/app/src/main/java/me/daei/soundmeter/widget/SoundDiscView.java
+++ b/app/src/main/java/me/daei/soundmeter/widget/SoundDiscView.java
@@ -8,8 +8,6 @@ import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.Gravity;
 import android.widget.ImageView;
 
 import me.daei.soundmeter.R;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessImportCheck - “Useless imports should be removed”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck

Please let me know if you have any questions.
Ayman Abdelghany.
