### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/me/daei/soundmeter/FileUtil.java
+++ b/app/src/main/java/me/daei/soundmeter/FileUtil.java
@@ -37,6 +37,9 @@ public class FileUtil {
         }
     }
 
+    private FileUtil() {
+    }
+
     /**
      * 判断是否存在存储空间	 *
      *

--- a/app/src/main/java/me/daei/soundmeter/ScreenUtil.java
+++ b/app/src/main/java/me/daei/soundmeter/ScreenUtil.java
@@ -9,6 +9,9 @@ import android.view.WindowManager;
  * Created by su on 2016/6/6.
  */
 public class ScreenUtil {
+    private ScreenUtil() {
+    }
+
     /**
      * 屏幕密度
      * @param context


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
